### PR TITLE
fastfetch: update dependencies on Linux

### DIFF
--- a/Formula/fastfetch.rb
+++ b/Formula/fastfetch.rb
@@ -26,8 +26,8 @@ class Fastfetch < Formula
   uses_from_macos "zlib" => :build
 
   on_linux do
+    depends_on "cjson" => :build
     depends_on "dbus" => :build
-    depends_on "json-c" => :build
     depends_on "libx11" => :build
     depends_on "libxcb" => :build
     depends_on "libxrandr" => :build


### PR DESCRIPTION
fastfetch actually uses cjson instead of json-c

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?